### PR TITLE
Update version and create a new version package on PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8]
+
+### Changed
+
+- Updated the `version` field to "0.1.8" in `pyproject.toml`
+- Updated the `python-version` field to "3.11" in `.github/workflows/release.yaml`
+
 ## [0.0.2]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "himatcal"
-version = "0.1.7"
+version = "0.1.8"
 description = "High throughput material calculation"
 authors = [{ name = "Congcong Sun", email = "suncongcong000@foxmail.com" }]
 license = { text = "BSD-3" }


### PR DESCRIPTION
Update the version and create a new version package on PyPI.

* **pyproject.toml**
  - Update the `version` field to "0.1.8".

* **CHANGELOG.md**
  - Add a new entry for version 0.1.8.
  - Mention the changes made in this version.

* **.github/workflows/release.yaml**
  - Update the `python-version` field to "3.11".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CCSun21/himatcal/pull/15?shareId=3e7ddf94-1360-4360-b2c3-7878d07bb98f).

## Summary by Sourcery

Update the package version to 0.1.8 and update the release workflow to use Python 3.11.

Enhancements:
- Update the Python version used in the release workflow to 3.11.

Chores:
- Update the package version to 0.1.8.